### PR TITLE
Main

### DIFF
--- a/infra/ai.yaml
+++ b/infra/ai.yaml
@@ -15,7 +15,7 @@ deployments:
       name: gpt-4o
       version: "2024-05-13"
     sku:
-      name: Standard
+      name: GlobalStandard
       capacity: 20
   - name: text-embedding-ada-002
     model:


### PR DESCRIPTION
Since 2025/02/13 the version of GPT-35-Turbo 0613 is not supported and causes the deployment to fail. If you deployment fails because of this, go to your github repo, to the file ./infra/ai.yaml, change on line 8 to version “0125”