### PR TITLE
GPT-35-Turbo

### DIFF
--- a/infra/ai.yaml
+++ b/infra/ai.yaml
@@ -5,7 +5,7 @@ deployments:
     model:
       format: OpenAI
       name: gpt-35-turbo
-      version: "0613"
+      version: "0125"
     sku:
       name: Standard
       capacity: 20


### PR DESCRIPTION
Since 2025/02/13 the version of GPT-35-Turbo 061GPT-35-Turbo3 is not supported and causes the deployment to fail. If you deployment fails because of this, go to your github repo, to the file ./infra/ai.yaml, change on line 8 to version “0125”